### PR TITLE
feat: implement dev/prod profiles and add api versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /server/.gradle
 /server/build
 /server/.idea
+/server/.db

--- a/server/.idea/workspace.xml
+++ b/server/.idea/workspace.xml
@@ -5,7 +5,16 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="ac7ca4b8-126a-44d3-b248-370c66135204" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/docs/api.md" beforeDir="false" afterPath="$PROJECT_DIR$/docs/api.md" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/docs/profiles.md" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/resources/application-dev.properties" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/resources/application-prod.properties" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/../.gitignore" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle.kts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/evsoft/api/HealthController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/evsoft/api/HealthController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/evsoft/api/TaskController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/evsoft/api/TaskController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/evsoft/mapper/TaskMapper.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/evsoft/mapper/TaskMapper.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.properties" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -96,13 +105,14 @@
     "Gradle.TodoControllerTest.executor": "Run",
     "Gradle.server [bootRun].executor": "Run",
     "Gradle.server [bootTestRun].executor": "Run",
+    "Gradle.server-prod [bootRun].executor": "Run",
     "ModuleVcsDetector.initialDetectionPerformed": "true",
     "RunOnceActivity.MCP Project settings loaded": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
-    "git-widget-placeholder": "fix-documentation-structure",
+    "git-widget-placeholder": "feature-profiles",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "C:/dev/Home/todo-manager/server",
@@ -111,11 +121,11 @@
     "node.js.selected.package.eslint": "(autodetect)",
     "node.js.selected.package.tslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "copyright",
+    "settings.editor.selected.configurable": "copyright.profiles",
     "vue.rearranger.settings.migration": "true"
   }
 }]]></component>
-  <component name="RunManager" selected="Gradle.server [bootRun]">
+  <component name="RunManager" selected="Gradle.server-prod [bootRun]">
     <configuration name="TaskControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -139,58 +149,6 @@
       <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
       <DebugAllEnabled>false</DebugAllEnabled>
       <RunAsTest>true</RunAsTest>
-      <GradleProfilingDisabled>false</GradleProfilingDisabled>
-      <GradleCoverageDisabled>false</GradleCoverageDisabled>
-      <method v="2" />
-    </configuration>
-    <configuration name="TodoControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;com.evsoft.api.TodoControllerTest&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <GradleProfilingDisabled>false</GradleProfilingDisabled>
-      <GradleCoverageDisabled>false</GradleCoverageDisabled>
-      <method v="2" />
-    </configuration>
-    <configuration name="server [bootRun]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value="bootRun" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>false</RunAsTest>
       <GradleProfilingDisabled>false</GradleProfilingDisabled>
       <GradleCoverageDisabled>false</GradleCoverageDisabled>
       <method v="2" />
@@ -220,6 +178,56 @@
       <GradleCoverageDisabled>false</GradleCoverageDisabled>
       <method v="2" />
     </configuration>
+    <configuration name="server-dev [bootRun]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="bootRun" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>false</RunAsTest>
+      <GradleProfilingDisabled>false</GradleProfilingDisabled>
+      <GradleCoverageDisabled>false</GradleCoverageDisabled>
+      <method v="2" />
+    </configuration>
+    <configuration name="server-prod [bootRun]" type="GradleRunConfiguration" factoryName="Gradle">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="bootRun" />
+          </list>
+        </option>
+        <option name="vmOptions" value="-Dspring.profiles.active=prod" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>false</RunAsTest>
+      <GradleProfilingDisabled>false</GradleProfilingDisabled>
+      <GradleCoverageDisabled>false</GradleCoverageDisabled>
+      <method v="2" />
+    </configuration>
     <configuration name="Server" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
       <module name="todo-server.main" />
       <option name="SPRING_BOOT_MAIN_CLASS" value="com.evsoft.Server" />
@@ -227,11 +235,17 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <list>
+      <item itemvalue="Gradle.server-prod [bootRun]" />
+      <item itemvalue="Gradle.server-dev [bootRun]" />
+      <item itemvalue="Gradle.server [bootTestRun]" />
+      <item itemvalue="Gradle.TaskControllerTest" />
+      <item itemvalue="Spring Boot.Server" />
+    </list>
     <recent_temporary>
       <list>
+        <item itemvalue="Gradle.server-dev [bootRun]" />
         <item itemvalue="Gradle.TaskControllerTest" />
-        <item itemvalue="Gradle.server [bootRun]" />
-        <item itemvalue="Gradle.TodoControllerTest" />
         <item itemvalue="Gradle.server [bootTestRun]" />
       </list>
     </recent_temporary>
@@ -255,7 +269,7 @@
       <workItem from="1772575396346" duration="349000" />
       <workItem from="1772611906875" duration="8652000" />
       <workItem from="1772727765338" duration="7889000" />
-      <workItem from="1772783186171" duration="17815000" />
+      <workItem from="1772783186171" duration="24902000" />
     </task>
     <servers />
   </component>

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 
 	implementation("org.springframework.boot:spring-boot-starter-security")
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 

--- a/server/docs/profiles.md
+++ b/server/docs/profiles.md
@@ -1,0 +1,50 @@
+## Environment and Profile Management
+
+This project uses Spring Profiles to manage different configurations for development and production environments. This ensures data safety and provides the right tools at the right stage of development.
+
+### Available Profiles
+
+* **dev (Default)**: H2 In-Memory, data is wiped on restart, H2 Console is enabled.
+* **prod**: H2 File-based, data is stored in ./db/, H2 Console is disabled.
+
+---
+
+### Configuration Details
+
+#### 1. Global Settings (application.properties)
+* API Prefix: /api/v1 (e.g., http://localhost:8080/api/v1/tasks)
+* Default Profile: dev
+
+#### 2. Development Profile (application-dev.properties)
+* JDBC URL: jdbc:h2:mem:taskdb
+* DDL Strategy: create-drop
+* Swagger UI: Enabled at /api/v1/swagger-ui.html
+
+#### 3. Production Profile (application-prod.properties)
+* JDBC URL: jdbc:h2:file:./db/task_manager;AUTO_SERVER=TRUE
+* DDL Strategy: update
+* Security: H2 Web Console and SQL logging are disabled.
+
+---
+
+### How to Switch Profiles
+
+#### Via IntelliJ IDEA
+1. Go to **Run/Debug Configurations**.
+2. Select your Application.
+3. In the **Active Profiles** field, enter: prod
+
+#### Via Command Line (Gradle)
+```
+./gradlew bootRun --args='--spring.profiles.active=prod'
+```
+---
+
+### Docker Integration
+
+When running in a container, use Volumes to ensure the database file survives.
+
+**Command:**
+```
+docker run -d --name task-manager -p 8080:8080 -e SPRING_PROFILES_ACTIVE=prod -v $(pwd)/db:/app/db your-image-name
+```

--- a/server/src/main/java/com/evsoft/api/HealthController.java
+++ b/server/src/main/java/com/evsoft/api/HealthController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/health")
+@RequestMapping("/health")
 @Tag(name = "Health", description = "Health check endpoints")
 public class HealthController {
     @GetMapping

--- a/server/src/main/java/com/evsoft/api/TaskController.java
+++ b/server/src/main/java/com/evsoft/api/TaskController.java
@@ -1,19 +1,17 @@
 /*
+ * Personal Task Manager
+ * Copyright (c) 2026 Vitalii Yeremenko
  *
- *  * Personal Task Manager
- *  * Copyright (c) ${YEAR} Vitalii Yeremenko
- *  *
- *  * Permission is hereby granted, free of charge, to any person obtaining a copy
- *  * of this software and associated documentation files (the "Software"), to deal
- *  * in the Software without restriction, including without limitation the rights
- *  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  * copies of the Software, and to permit persons to whom the Software is
- *  * furnished to do so, subject to the following conditions:
- *  *
- *  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
  */
 package com.evsoft.api;
 
@@ -35,7 +33,7 @@ import java.util.List;
  * Handles HTTP requests and delegates business logic to {@link TaskService}.
  */
 @RestController
-@RequestMapping("/api/v1/tasks")
+@RequestMapping("/tasks")
 @RequiredArgsConstructor
 @Tag(name = "Tasks", description = "API for task management operations")
 public class TaskController {

--- a/server/src/main/java/com/evsoft/mapper/TaskMapper.java
+++ b/server/src/main/java/com/evsoft/mapper/TaskMapper.java
@@ -1,19 +1,17 @@
 /*
+ * Personal Task Manager
+ * Copyright (c) 2026 Vitalii Yeremenko
  *
- *  * Personal Task Manager
- *  * Copyright (c) ${YEAR} Vitalii Yeremenko
- *  *
- *  * Permission is hereby granted, free of charge, to any person obtaining a copy
- *  * of this software and associated documentation files (the "Software"), to deal
- *  * in the Software without restriction, including without limitation the rights
- *  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  * copies of the Software, and to permit persons to whom the Software is
- *  * furnished to do so, subject to the following conditions:
- *  *
- *  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
  */
 package com.evsoft.mapper;
 

--- a/server/src/main/resources/application-dev.properties
+++ b/server/src/main/resources/application-dev.properties
@@ -1,0 +1,17 @@
+spring.datasource.url=jdbc:h2:mem:task-db;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+
+springdoc.use-management-port=false
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.config-url=/api/v1/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/api/v1/v3/api-docs
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/server/src/main/resources/application-prod.properties
+++ b/server/src/main/resources/application-prod.properties
@@ -1,0 +1,13 @@
+spring.datasource.url=jdbc:h2:file:./.db/data
+spring.datasource.username=sa
+spring.datasource.password=Test123$
+
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.show-sql=false
+spring.h2.console.enabled=false
+
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false
+
+spring.jpa.properties.hibernate.format_sql=false

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,11 +1,8 @@
-spring.datasource.url=jdbc:h2:mem:task-db
 spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.show-sql=true
-
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=update
+server.servlet.context-path=/api/v1
+server.port = 8080
 
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+# Use dev profile by default
+spring.profiles.active=dev
+


### PR DESCRIPTION
Fixes: https://github.com/veter32/todo-manager/issues/2, https://github.com/veter32/todo-manager/issues/6

## Summary

This PR introduces Spring Profiles to separate development and production environments, implements data persistence for production, and adds API versioning.

## Key Changes
### Environment Separation:
- dev: Uses H2 In-Memory database (fast, clean state).
- prod: Uses H2 File-based database (stored in ./db/) for data persistence.

### API Versioning: 

- Added server.servlet.context-path=/api/v1 to all endpoints.
- Swagger/OpenAPI: Upgraded springdoc-openapi to 2.7.0 to fix compatibility issues with Spring Boot 3.4+.

Fixed Swagger UI routing under the new context path.

## Infrastructure: 

Updated .gitignore to exclude the local database folder and added PROFILES.md documentation.

## How to Test

### Check Dev Mode:

Run the app with the default profile. Verify Swagger is accessible at http://localhost:8080/api/v1/swagger-ui.html.

### Check Prod Mode:
Run with --spring.profiles.active=prod.

Verify that a .db folder is created in the project root.

Create a task, restart the app, and verify the task still exists (persistence check).

Check API: Confirm all endpoints now require the /api/v1 prefix.

### Note
The local database file is now ignored by Git. Each developer will have their own local persistent storage when running in prod mode.