### PR TITLE
feat: Add security layer

### DIFF
--- a/server/.idea/modules.xml
+++ b/server/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/todo-server.main.iml" filepath="$PROJECT_DIR$/.idea/modules/todo-server.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/todo-server.test.iml" filepath="$PROJECT_DIR$/.idea/modules/todo-server.test.iml" />
     </modules>
   </component>
 </project>

--- a/server/.idea/workspace.xml
+++ b/server/.idea/workspace.xml
@@ -5,11 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="ac7ca4b8-126a-44d3-b248-370c66135204" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/docs/security.md" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/evsoft/api/SecurityTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/modules.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/evsoft/config/OpenApiConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/evsoft/config/OpenApiConfig.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/evsoft/config/SecurityConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/evsoft/config/SecurityConfig.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/com/evsoft/api/TaskControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/com/evsoft/api/TaskControllerTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -109,7 +111,7 @@
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
-    "git-widget-placeholder": "master",
+    "git-widget-placeholder": "feature-security-layer",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "C:/dev/Home/todo-manager/server",
@@ -122,7 +124,7 @@
     "vue.rearranger.settings.migration": "true"
   }
 }]]></component>
-  <component name="RunManager" selected="Gradle.Tests in 'com.evsoft.api'">
+  <component name="RunManager" selected="Gradle.server-prod [bootRun]">
     <configuration name="TaskControllerTest.shouldAddNewTaskSuccessfully" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -325,6 +327,7 @@
       <workItem from="1772611906875" duration="8652000" />
       <workItem from="1772727765338" duration="7889000" />
       <workItem from="1772783186171" duration="24902000" />
+      <workItem from="1772958711331" duration="1463000" />
     </task>
     <servers />
   </component>

--- a/server/README.md
+++ b/server/README.md
@@ -44,4 +44,5 @@ Windows `gradlew bootRun`
 Detailed technical guides are available in the `docs/` directory:
 
 * [** REST API Specification**](./docs/api.md) — Full list of endpoints, request/response JSON examples, and status codes.
+* [** Security API Specification**](./docs/security.md) — Information about security layer.
 * [** Docker Setup Guide**](./docs/docker.md) — Instructions on how to containerize the server and run it with PostgreSQL.

--- a/server/docs/security.md
+++ b/server/docs/security.md
@@ -1,0 +1,40 @@
+# Security Specification
+
+This project implements an authentication and authorization system to protect personal data and manage API access.
+
+---
+
+## Authentication Mechanism
+
+The API uses the **HTTP Basic Authentication** protocol. This means that every protected request must include credentials in the Authorization header.
+
+* **Type:** Basic Auth
+* **Header Format:** Authorization: Basic <base64(username:password)>
+* **Password Hashing:** All passwords in the system are stored encrypted using the **BCrypt** hashing algorithm.
+
+---
+
+## Access Rules
+
+| Endpoint | Method | Access | Description |
+| :--- | :--- | :--- | :--- |
+| /api/v1/tasks/** | ANY | ROLE_ADMIN | Core task management API. |
+| /api/v1/swagger-ui/** | GET | PermitAll | Documentation web interface. |
+| /v3/api-docs/** | GET | PermitAll | OpenAPI specification (JSON/YAML). |
+
+> Note: Documentation resources (Swagger) are open without authentication to facilitate integration; however, executing requests from the UI requires entering credentials via the Authorize button.
+
+---
+
+## Testing and Development
+
+A static administrator account has been created for the local environment:
+
+* Username: admin
+* Password: password
+
+### CLI Request Example
+`curl -X GET http://localhost:8080/api/v1/tasks -u admin:password`
+
+### Testing with MockMvc (JUnit)
+Tests use the `@WithMockUser(roles = "ADMIN")` annotation to simulate a security context without actually passing HTTP headers. This allows for isolated business logic testing.

--- a/server/src/main/java/com/evsoft/config/OpenApiConfig.java
+++ b/server/src/main/java/com/evsoft/config/OpenApiConfig.java
@@ -15,8 +15,11 @@
  */
 package com.evsoft.config;
 
-import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,10 +28,18 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "basicAuth";
         return new OpenAPI()
                 .info(new Info()
                         .title("Personal Task Manager API")
                         .version("1.0")
-                        .description("REST API for Personal Task Manager project"));
+                        .description("REST API for Personal Task Manager project"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")));
     }
 }

--- a/server/src/main/java/com/evsoft/config/SecurityConfig.java
+++ b/server/src/main/java/com/evsoft/config/SecurityConfig.java
@@ -43,7 +43,13 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/v3/api-docs.yaml",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/webjars/**" // Важно: здесь лежат иконки и скрипты Swagger
+                            ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(Customizer.withDefaults());

--- a/server/src/test/java/com/evsoft/api/SecurityTest.java
+++ b/server/src/test/java/com/evsoft/api/SecurityTest.java
@@ -1,0 +1,62 @@
+/*
+ * Personal Task Manager
+ * Copyright (c) ${YEAR} Vitalii Yeremenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ */
+
+package com.evsoft.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturn401WhenAccessingTasksWithoutAuth() throws Exception {
+        mockMvc.perform(get("/tasks"))
+               .andExpect(status().isUnauthorized()); // Ждем 401
+    }
+
+    @Test
+    void shouldReturn401WithWrongCredentials() throws Exception {
+        mockMvc.perform(get("/tasks")
+                        .with(httpBasic("admin", "wrong-password")))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldReturn200WithValidCredentials() throws Exception {
+        mockMvc.perform(get("/tasks")
+                        .with(httpBasic("admin", "password")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldAllowAccessToSwaggerWithoutAuth() throws Exception {
+        // Проверяем, что наши исключения в SecurityConfig работают
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Overview
This PR implements a security layer using Spring Security with Basic Authentication. It secures all task-related endpoints while keeping API documentation accessible for integration purposes.

## Key Changes
- **Spring Security Integration**: Added `SecurityConfig` to protect `/api/v1/tasks/**` endpoints.
- **Authentication**: Configured HTTP Basic Auth with an in-memory `admin` user and BCrypt password encoding.
- **Swagger/OpenAPI**: 
    - Added `OpenApiConfig` to enable the "Authorize" button in Swagger UI.
    - Configured security schemes so users can test protected endpoints directly from the browser.
- **Testing**:
    - Integrated `spring-security-test`.
    - Added `SecurityTest` to verify 401 Unauthorized responses for anonymous requests.
    - Updated `TaskControllerTest` using `@WithMockUser` to maintain test suite green status.
- **Documentation**: 
    - Created `security.md` with detailed authentication specs.
    - Linked security requirements in `api.md`.

## Security Details
- **Algorithm**: BCrypt
- **Roles**: `ROLE_ADMIN`
- **Protected Paths**: `/api/v1/tasks/**`
- **Public Paths**: `/swagger-ui/**`, `/v3/api-docs/**`

## Verification Steps
1. **Automated Tests**: Run `./gradlew test` (or run `TaskControllerTest` and `SecurityTest` in IDEA). All tests should pass.
2. **Manual Check (Swagger)**:
    - Open `http://localhost:8080/api/v1/swagger-ui/index.html`.
    - Try to `GET /tasks` -> should return 401.
    - Click **Authorize**, enter `admin`/`password`.
    - Try to `GET /tasks` again -> should return 200 OK.
3. **Manual Check (cURL)**:
    - Run: `curl -u admin:password http://localhost:8080/api/v1/tasks`
